### PR TITLE
Added left right strafing instead of A and D being rotational

### DIFF
--- a/js/char.js
+++ b/js/char.js
@@ -1177,12 +1177,20 @@ function Player(x, y, z) {
             }
         }
         if (this.keyboard.pressed("A")) {
-            this.chunk.mesh.rotation.y += (this.speed * delta / 7);
-            this.moving = true;
+            this.chunk.mesh.translateX(this.speed * delta);
+            if(this.cd()) {
+                this.moving = true;
+            } else {
+                this.chunk.mesh.translateX(-this.speed * delta);
+            }
         }
         if (this.keyboard.pressed("D")) {
-            this.chunk.mesh.rotation.y -= (this.speed * delta / 7);
-            this.moving = true;
+            this.chunk.mesh.translateX(-this.speed * delta);
+            if(this.cd()) {
+                this.moving = true;
+            } else {
+                this.chunk.mesh.translateX(this.speed * delta);
+            }
         }
         if (this.keyboard.pressed("R")) {
             this.flashlight.visible = false;


### PR DESCRIPTION
WASD controls usually allow for A and D to be strafing mechanisms instead of rotation. Although now it's impossible to play without a mouse!

Perhaps adding in the addition of arrow keys that move the player forward and back along with left and right being rotate will allow non-mouse users to play?

_Note: Diagonal movement needs normalisation, which is more work than I am able to put in at this very moment._